### PR TITLE
add product version  info metric for hosts

### DIFF
--- a/tests/unit/test_vmware_exporter.py
+++ b/tests/unit/test_vmware_exporter.py
@@ -498,6 +498,8 @@ def test_collect_hosts():
                 'summary.hardware.cpuMhz': 1000,
                 'summary.quickStats.overallMemoryUsage': 1024,
                 'summary.hardware.memorySize': 2048 * 1024 * 1024,
+                'summary.config.product.version': '6.0.0',
+                'summary.config.product.build': '6765062',
             },
             'host:2': {
                 'id': 'host:2',
@@ -515,6 +517,15 @@ def test_collect_hosts():
     }
     assert metrics['vmware_host_memory_max'].samples[0][2] == 2048
     assert metrics['vmware_host_num_cpu'].samples[0][2] == 12
+
+    assert metrics['vmware_host_product_info'].samples[0][1] == {
+        'host_name': 'host-1',
+        'dc_name': 'dc',
+        'cluster_name': 'cluster',
+        'version': '6.0.0',
+        'build': '6765062',
+    }
+    assert metrics['vmware_host_product_info'].samples[0][2] == 1
 
     # In our test data we hava a host that is powered down - we should have its
     # power_state metric but not any others.

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -172,6 +172,10 @@ class VmwareCollector():
                 'vmware_host_memory_max',
                 'VMWare Host Memory Max availability in Mbytes',
                 labels=['host_name', 'dc_name', 'cluster_name']),
+            'vmware_host_product_info': GaugeMetricFamily(
+                'vmware_host_product_info',
+                'A metric with a constant "1" value labeled by version and build from os the host.',
+                labels=['host_name', 'dc_name', 'cluster_name', 'version', 'build']),
             }
 
         metrics = {}
@@ -305,6 +309,8 @@ class VmwareCollector():
             'summary.hardware.numCpuCores',
             'summary.hardware.cpuMhz',
             'summary.hardware.memorySize',
+            'summary.config.product.version',
+            'summary.config.product.build',
             'runtime.powerState',
             'runtime.bootTime',
             'runtime.connectionState',
@@ -770,6 +776,14 @@ class VmwareCollector():
                     labels,
                     float(host['summary.hardware.memorySize']) / 1024 / 1024
                 )
+
+
+            config_ver = host.get('summary.config.product.version', 'unknown')
+            build_ver = host.get('summary.config.product.build', 'unknown')
+            host_metrics['vmware_host_product_info'].add_metric(
+                labels + [config_ver, build_ver],
+                1
+            )
 
         logging.info("Finished host metrics collection")
         return results

--- a/vmware_exporter/vmware_exporter.py
+++ b/vmware_exporter/vmware_exporter.py
@@ -777,7 +777,6 @@ class VmwareCollector():
                     float(host['summary.hardware.memorySize']) / 1024 / 1024
                 )
 
-
             config_ver = host.get('summary.config.product.version', 'unknown')
             build_ver = host.get('summary.config.product.build', 'unknown')
             host_metrics['vmware_host_product_info'].add_metric(


### PR DESCRIPTION
retreive "summary.config.product.version" and "summary.config.product.build" from hosts to populate ESX version and build pseudo metric.

The metrics look like:

    # HELP vmware_host_product_info A metric with a constant "1" value labeled by version and build from os the host.
    # TYPE vmware_host_product_info gauge
    vmware_host_product_info{version="6.0.0", build="6765062", ...}